### PR TITLE
Fix several issues related to exceptions, including #7 and #8

### DIFF
--- a/sample/exception.newt
+++ b/sample/exception.newt
@@ -18,12 +18,24 @@ begin
 		Throw('|evt.ex.foo;type.ref.frame|, {});
 	onexception |evt.ex.foo| do
 		Print("Caught custom with data\n");
-	
+
 	// Catch and print data.
 	try
 		Throw('|evt.ex.foo;type.ref.string|, "Some data");
 	onexception |evt.ex.foo| do
 		Print("Caught: " & CurrentException().data & "\n");
+
+	// Catch custom with subexception.
+	try
+		Throw('|evt.ex.foo.sub|, nil);
+	onexception |evt.ex.foo| do
+		Print("Caught custom sub\n");
+
+	// Catch custom with subexception and Apply
+	try
+		Apply(GetGlobalFn('Throw), ['|evt.ex.foo.sub|, nil]);
+	onexception |evt.ex.foo| do
+		Print("Caught custom sub with apply\n");
 	
 	// Don't catch.
 	try

--- a/src/newt_core/NewtGC.c
+++ b/src/newt_core/NewtGC.c
@@ -465,20 +465,18 @@ void NewtGCStackMark(vm_env_t * env, bool mark)
     // 例外ハンドラ・スタック
     NewtGCRefMark(env->currexcp, mark);
 
-/*
     {
         vm_excp_t *	excpstack;
         vm_excp_t *	excp;
 
         excpstack = (vm_excp_t *)env->excpstack.stackp;
 
-        for (i = 0; i < env->excpsp; i++)
+        for (i = 0; i < env->excpstack.sp; i++)
         {
             excp = &excpstack[i];
             NewtGCRefMark(excp->sym, mark);
         }
     }
-*/
 }
 
 

--- a/src/newt_core/incs/NewtBC.h
+++ b/src/newt_core/incs/NewtBC.h
@@ -38,7 +38,7 @@ enum {
     kNBCSetLexScope			= 004,	// 004 set-lex-scope
     kNBCIterNext			= 005,	// 005 iter-next
     kNBCIterDone			= 006,	// 006 iter-done
-    kNBCPopHandlers			= 007	// 007 000 001 pop-handlers
+    kNBCPopHandlers			= 007	// 007 000 007 pop-handlers
 };
 
 

--- a/src/newt_core/incs/NewtFns.h
+++ b/src/newt_core/incs/NewtFns.h
@@ -161,6 +161,7 @@ newtRef		NsExit(newtRefArg rcvr, newtRefArg r);
 newtRef		NsCompile(newtRefArg rcvr, newtRefArg r);
 newtRef		NsGetEnv(newtRefArg rcvr, newtRefArg r);
 
+newtRef		NsBinEqual(newtRefArg rcvr, newtRefArg a, newtRefArg b);
 newtRef		NsExtractByte(newtRefArg rcvr, newtRefArg r, newtRefArg offset);
 newtRef		NsExtractWord(newtRefArg rcvr, newtRefArg r, newtRefArg offset);
 

--- a/src/newt_core/incs/NewtType.h
+++ b/src/newt_core/incs/NewtType.h
@@ -125,8 +125,9 @@ enum {
 
 /* 型宣言 */
 
-// Ref(Integer, Pointer, Charcter, Spatial, Magic pointer)
+// Ref(Integer, Pointer, Character, Special, Magic pointer)
 typedef uintptr_t		newtRef;		///< オブジェクト参照
+// NewtGC() is only called when there should be no lingering newtRefVar on the stack.
 typedef newtRef			newtRefVar;		///< オブジェクト参照変数
 typedef const newtRef	newtRefArg;		///< オブジェクト参照引数
 

--- a/src/newt_core/incs/NewtVM.h
+++ b/src/newt_core/incs/NewtVM.h
@@ -95,6 +95,7 @@ typedef struct {
 /// 例外ハンドラ
 typedef struct {
     uint32_t	callsp;		///< 呼出しスタックのスタックポインタ
+    uint32_t	sp;			///< Saved stack pointer
     uint32_t	excppc;		///< 例外ハンドラを作成したときのプログラムカウンタ
 
     newtRefVar	sym;		///< シンボル
@@ -141,9 +142,9 @@ newtRef		NVMSelf(void);
 newtRef		NVMCurrentFunction(void);
 newtRef		NVMCurrentImplementor(void);
 bool		NVMHasVar(newtRefArg name);
-void		NVMThrowData(newtRefArg name, newtRefArg data);
-void		NVMThrow(newtRefArg name, newtRefArg data);
-void		NVMRethrow(void);
+newtRef		NVMThrowData(newtRefArg name, newtRefArg data);
+newtRef		NVMThrow(newtRefArg name, newtRefArg data);
+newtRef		NVMRethrow(void);
 newtRef		NVMCurrentException(void);
 void		NVMClearException(void);
 

--- a/tests/test_common.newt
+++ b/tests/test_common.newt
@@ -1,0 +1,105 @@
+func TestEquality(x, y)
+begin
+    local equal := nil;
+    if IsImmediate(x) then equal := x = y;
+    if IsBinary(x) then equal := IsBinary(y) and BinEqual(x, y);
+    if IsFrame(x) then begin
+        if IsFrame(y) and Length(x) = Length(y) then
+        begin
+            equal := true;
+            foreach k, v in x do
+                equal := equal and HasSlot(k, y) and TestEquality(v, y.k)
+        end;
+    end;
+    if IsArray(x) then begin
+        if IsArray(y) and Length(x) = Length(y) then
+        begin
+            equal := true;
+            foreach k, v in x do
+                equal := equal and TestEquality(v, y[k])
+        end;
+    end;
+    return equal;
+end;
+
+global protoTestCase := {
+    Run: func()
+    begin
+        local finalResult := true;
+        foreach k, v in self do
+        begin
+            local symbolAsStr := k & "";
+            if BeginsWith(symbolAsStr, "test") and IsFunction(v) then
+            begin
+                local len := StrLen(symbolAsStr);
+                while len < 70 do
+                begin
+                    symbolAsStr := symbolAsStr & ".";
+                    len := len + 1;
+                end;
+                Print(symbolAsStr);
+                local resultStr := "OK";
+                local failedException := nil;
+                try
+                    Perform(self, k, []);
+                onexception |evt.ex.test| do
+                begin
+                    resultStr := "FAILED";
+                    finalResult := nil;
+                    failedException := CurrentException();
+                end
+                onexception |evt| do
+                begin
+                    resultStr := "ERROR";
+                    finalResult := nil;
+                    failedException := CurrentException();
+                end;
+                Print(" " & resultStr & "\n");
+                if failedException then
+                    P(failedException);
+            end;
+        end;
+        return finalResult;
+    end,
+
+    AssertTrue: func(x)
+    begin
+        if not x then
+        begin
+            Throw('|evt.ex.test.assertTrueFailed|, {x: x})
+        end;
+    end,
+    
+    AssertEqual: func(x, y)
+    begin
+        if not TestEquality(x, y) then
+        begin
+            Throw('|evt.ex.test.assertEqualFailed|, {x: x, y: y})
+        end;
+    end,
+
+    AssertEqualDelta: func(x, y, delta)
+    begin
+        if x > y + delta or x < y - delta then
+        begin
+            Throw('|evt.ex.test.assertEqualDeltaFailed|, {x: x, y: y, delta: delta})
+        end;
+    end,
+    
+    AssertThrow: func(sym, closure)
+    begin
+        local caught := nil;
+        local exception := nil;
+        try
+            call closure with ()
+        onexception |evt| do
+        begin
+            exception := CurrentException();
+            caught := HasSubclass(exception.name, sym);
+        end;
+        if not caught then
+        begin
+            Throw('|evt.ex.test.assertThrowFailed|, {sym: sym, exception: exception, closure: closure})
+        end;
+    end,
+};

--- a/tests/test_exceptions.newt
+++ b/tests/test_exceptions.newt
@@ -1,0 +1,112 @@
+#!newt
+
+if not load("test_common.newt") then
+begin
+    Print("Could not load test_common.newt\n");
+    Exit(1);
+end;
+
+local testCases := [
+    {
+        _proto: protoTestCase,
+        testCatchBuiltIn: func() begin
+            :AssertThrow('|evt.ex.fr|, func() begin
+                5 / 0
+            end);
+            :AssertTrue(begin
+                local caught := nil;
+                try
+                    5 / 0
+                onexception |evt.ex.fr| do
+                    caught := true;
+                caught
+            end)
+        end,
+        testCatchCustom: func() begin
+            :AssertTrue(begin
+                local caught := nil;
+                try
+                    Throw('|evt.ex.foo|, nil)
+                onexception |evt.ex.foo| do
+                    caught := true;
+                caught
+            end)
+        end,
+        testCatchCustomWithData: func() begin
+            :AssertEqual({}, begin
+                local result := nil;
+                try
+                    Throw('|evt.ex.foo;type.ref.frame|, {})
+                onexception |evt.ex.foo| do
+                    result := CurrentException().data;
+                result
+            end)
+        end,
+        testCatchCustomWithString: func() begin
+            :AssertEqual("Some data", begin
+                local result := nil;
+                try
+                    Throw('|evt.ex.foo;type.ref.string|, "Some data")
+                onexception |evt.ex.foo| do
+                    result := CurrentException().data;
+                result
+            end)
+        end,
+        testCatchCustomWithSubException: func() begin
+            :AssertTrue(begin
+                local caught := nil;
+                try
+                    Throw('|evt.ex.foo.sub|, nil)
+                onexception |evt.ex.foo| do
+                    caught := true;
+                caught
+            end)
+        end,
+        testCatchCustomWithApply: func() begin
+            :AssertTrue(begin
+                local caught := nil;
+                try
+                    Apply(GetGlobalFn('Throw), ['|evt.ex.foo.sub|, nil])
+                onexception |evt.ex.foo| do
+                    caught := true;
+                caught
+            end)
+        end,
+        testCatchCustomWithPerform: func() begin
+            :AssertTrue(begin
+                local caught := nil;
+                try
+                    Perform({throw: func() begin Throw('|evt.ex.foo.sub|, nil) end}, 'throw, [])
+                onexception |evt.ex.foo| do
+                    caught := true;
+                caught
+            end)
+        end,
+        testRethrow: func() begin
+            :AssertTrue(begin
+                local caught := nil;
+                local recaught := nil;
+                try
+                    try
+                        Throw('|evt.ex.foo|, nil);
+                    onexception |evt.ex.foo| do
+                    begin
+                        caught := true;
+                        Rethrow();
+                    end;
+                onexception |evt.ex.foo| do
+                    recaught := true;
+                caught and recaught
+            end)
+        end,
+    }
+];
+
+local finalResult := true;
+
+foreach tc in testCases do
+begin
+    finalResult := finalResult && tc:Run();
+end;
+
+if not finalResult then Exit(1);


### PR DESCRIPTION
Exceptions are now propagated through saved vm environments (#8).
Pop-handler and pop are generated in the right sequence, following NewtonOS
compiler, fixing #7
Fix si_set_lex_scope for native functions.
Add unit tests for various cases.
Add BinEqual function for tests.