### PR TITLE
Add several compilation optimization from NewtonOS

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,7 @@
 enum {
     optNone			= 0,
     optNos2,
+    optNos1Functions,
     optCopyright,
     optVersion,
     optStaff,
@@ -46,6 +47,7 @@ static keyword_t	reserved_words[] = {
         // アルファベット順にソートしておくこと
         {"copyright",	optCopyright},
         {"newton",		optNos2},
+        {"nos1Functions",	optNos1Functions},
         {"nos2",		optNos2},
         {"staff",		optStaff},
         {"version",		optVersion},
@@ -361,6 +363,11 @@ void newt_option(const char * s)
 			NEWT_MODE_NOS2 = true;
 			break;
 
+		// As opposed to NewtonOS 2.x-only faster functions
+		case optNos1Functions:
+			NEWT_MODE_NOS1_FUNCTIONS = true;
+			break;
+
         // コピーライト
         case optCopyright:
             newt_show_copyright();
@@ -445,8 +452,7 @@ int main (int argc, const char * argv[])
         if (*s == '-')
         {
             newt_option(s + 1);
-            i++;
-            break;
+            continue;
         }
 
         switch (*s)

--- a/src/newt_core/NewtBC.c
+++ b/src/newt_core/NewtBC.c
@@ -38,6 +38,8 @@ struct nbc_env_t {
     newtRefVar	literals;		///< 関数オブジェクトのリテラルフレーム
     newtRefVar	argFrame;		///< 関数オブジェクトのフレーム
     newtRefVar	constant;		///< 定数フレーム
+
+    bool		needargframe;	///< Whether function needs argFrame because of set-lex-scope or find-var
 };
 
 
@@ -62,6 +64,7 @@ typedef struct {
 #define	LITERALS				(newt_bc_env->literals)							///< 作成中関数オブジェクトのリテラル
 #define	ARGFRAME				(newt_bc_env->argFrame)							///< 作成中関数オブジェクトの引数フレーム
 #define	CONSTANT				(newt_bc_env->constant)							///< 定数フレーム
+#define NEEDARGFRAME			(newt_bc_env->needargframe)						///< Whether we need argFrame
 
 #define NBCAddLiteral(r)		NBCAddLiteralEnv(newt_bc_env, r)				///< リテラルリストにオブジェクトを追加
 #define NBCGenCode(a, b)		NBCGenCodeEnv(newt_bc_env, a, b)				///< バイトコードを生成
@@ -380,8 +383,10 @@ void NBCGenGetVar(nps_syntax_node_t * stree, newtRefArg r)
     
         if (b != -1)
             NBCGenCode(kNBCGetVar, b);
-        else
+        else {
+            NEEDARGFRAME = true;
             NBCGenCodeL(kNBCFindVar, r);
+        }
     }
 }
 
@@ -506,8 +511,9 @@ int16_t NBCMakeFnArgs(newtRefArg fn, nps_syntax_node_t * stree, nps_node_t r)
         argFrame = NcGetSlot(fn, NSSYM0(argFrame));
         numArgs = NBCMakeFnArgFrame(argFrame, stree, r, &indefinite);
 
+        // We don't know yet how many locals we will have
         if (0 < numArgs)
-            NcSetSlot(fn, NSSYM0(numArgs), NewtMakeInteger(numArgs));
+            NcSetSlot(fn, NSSYM0(numArgs), MakeFFNumArgs(numArgs, 0));
  
 		if (indefinite)
             NcSetSlot(fn, NSSYM0(indefinite), kNewtRefTRUE);
@@ -798,8 +804,14 @@ void NBCOnexcpBackPatchL(uint32_t sp, int32_t pc)
 
 newtRef NBCMakeFn(nbc_env_t * env)
 {
+    newtRefVar funcClass;
+    if (NEWT_MODE_NOS1_FUNCTIONS) {
+        funcClass = NSSYM0(CodeBlock);
+    } else {
+        funcClass = kNewtFastFunctionClass;  // fasterFunctions
+    }
     newtRefVar	fnv[] = {
-                            NS_CLASS,				NSSYM0(CodeBlock),
+                            NS_CLASS,				funcClass,
                             NSSYM0(instructions),	kNewtRefNIL,
                             NSSYM0(literals),		kNewtRefNIL,
                             NSSYM0(argFrame),		kNewtRefNIL,
@@ -824,11 +836,10 @@ newtRef NBCMakeFn(nbc_env_t * env)
     // function
     fn = NewtMakeFrame2(sizeof(fnv) / (sizeof(newtRefVar) * 2), fnv);
 
-//    NcSetClass(fn, NSSYM0(CodeBlock));
     NcSetSlot(fn, NSSYM0(instructions), kNewtRefNIL);
     NcSetSlot(fn, NSSYM0(literals), env->literals);
     NcSetSlot(fn, NSSYM0(argFrame), env->argFrame);
-    NcSetSlot(fn, NSSYM0(numArgs), NewtMakeInteger(numArgs));
+    NcSetSlot(fn, NSSYM0(numArgs), MakeFFNumArgs(numArgs, 0));
 
     env->func = fn;
 
@@ -927,7 +938,6 @@ newtRef NBCFnDone(nbc_env_t ** envP)
     {
         newtRefVar	instr;
         newtRefVar	literals;
-        newtRefVar	numArgs;
 
         NBCGenCodeEnv(env, kNBCReturn, 0);
 
@@ -940,11 +950,25 @@ newtRef NBCFnDone(nbc_env_t ** envP)
         if (NewtRefIsNotNIL(literals) && NewtLength(literals) == 0)
             NcSetSlot(fn, NSSYM0(literals), kNewtRefNIL);
 
-        // Drop argframe if it is just empty
-        // A fasterFunctions optimization
-        numArgs = NcGetSlot(fn, NSSYM0(numArgs));
-        if (NewtRefIsLiteral(numArgs) && NewtLength(env->argFrame) == 3 + NewtRefToInteger(numArgs))
-            NcSetSlot(fn, NSSYM0(argFrame), kNewtRefNIL);
+        // FasterFunctions optimization
+        if (!NEWT_MODE_NOS1_FUNCTIONS) {
+            newtRefVar	indefinite;
+            size_t		numArgs;
+            size_t		numLocals;
+            // Drop argframe if we never call set-lex-scope
+            if (!NEEDARGFRAME) {;
+                NcSetSlot(fn, NSSYM0(argFrame), kNewtRefNIL);
+            }
+            // Set numArgs to (min)NumArgs + (0x10000 * number of local variables)
+            numArgs = FFNumArgsToNumArgs(NcGetSlot(fn, NSSYM0(numArgs)));
+            indefinite = NcGetSlot(fn, NSSYM0(indefinite));
+            numLocals = NewtFrameLength(ARGFRAME) - numArgs - 3;
+            if (NewtRefIsNotNIL(indefinite))
+                numLocals--;
+            if (numLocals) {
+                NcSetSlot(fn, NSSYM0(numArgs), MakeFFNumArgs(numArgs, numLocals));
+            }
+        }
 
         *envP = env->parent;
         NBCEnvFree(env);
@@ -1856,13 +1880,15 @@ void NBCGenAssign(nps_syntax_node_t * stree,
         // If variable is in argframe, we don't need to find it
         b = NewtFindSlotIndex(ARGFRAME, lvalue);
         if (b == -1) {
+            NEEDARGFRAME = true;
             NBCGenCodeL(kNBCFindAndSetVar, lvalue);
+            if (ret)
+                NBCGenCodeL(kNBCFindVar, lvalue);
         } else {
             NBCGenCode(kNBCSetVar, b);
+            if (ret)
+                NBCGenCodeL(kNBCGetVar, lvalue);
         }
-
-        if (ret)
-            NBCGenCodeL(kNBCFindVar, lvalue);
     }
 #ifdef __NAMED_MAGIC_POINTER__
 	else if (NewtRefIsNamedMP(lvalue))
@@ -2024,15 +2050,24 @@ void NBCGenFn(nps_syntax_node_t * stree, nps_node_t args, nps_node_t expr)
 {
     newtRefVar	fn;
     newtRefVar argFrame;
+    size_t     numLocals;
+    int        funcType;
 
     (void) NBCMakeFnEnv(stree, args);
     NBCGenBC_op(stree, expr);
     fn = NBCFnDone(&newt_bc_env);
     NBCGenPUSH(fn);
     argFrame = NcGetSlot(fn, NSSYM0(argFrame));
-    // Only set scope if called function has an argFrame.
-    if (NewtRefIsFrame(argFrame) && NewtFrameLength(argFrame) > 3)
+    numLocals = FFNumArgsToLocals(NcGetSlot(fn, NSSYM0(numArgs)));
+    // set-lex-scope is required:
+    // - if function is a classic CodeBlock function
+    // - if function is a kNewtFastFunction with local variables/argFrame
+    funcType = NewtRefFunctionType(fn);
+    if (funcType == kNewtCodeBlock
+        || (funcType == kNewtFastFunction && (NewtRefIsNotNIL(argFrame) || numLocals > 0))) {
+        NEEDARGFRAME = true;
         NBCGenCode(kNBCSetLexScope, 0);
+    }
 }
 
 

--- a/src/newt_core/NewtEnv.c
+++ b/src/newt_core/NewtEnv.c
@@ -219,6 +219,10 @@ void NewtInitSYM(void)
     INITSYM(_ENV_);
     INITSYM(NEWTLIB);
 
+    // Compile options
+    INITSYM(nosCompatible);
+    INITSYM(nos1Functions);
+
 	// ARGV
     INITSYM(_ARGV_);
     INITSYM(_EXEDIR_);

--- a/src/newt_core/NewtFns.c
+++ b/src/newt_core/NewtFns.c
@@ -2196,6 +2196,51 @@ newtRef NsGetEnv(newtRefArg rcvr, newtRefArg r)
 }
 
 
+/*------------------------------------------------------------------------*/
+/** Get compilation options applying to further calls to Compile
+ *
+ * @param rcvr		[in] レシーバ
+ *
+ * @return			Frame representing new compilation mode.
+ */
+
+newtRef NsGetCompileOptions(newtRefArg rcvr)
+{
+    newtRefVar result = NcMakeFrame();
+    NcSetSlot(result, NSSYM0(nosCompatible), NewtMakeBoolean(NEWT_MODE_NOS2));
+    NcSetSlot(result, NSSYM0(nos1Functions), NewtMakeBoolean(NEWT_MODE_NOS1_FUNCTIONS));
+
+    return result;
+}
+
+
+/*------------------------------------------------------------------------*/
+/** Set compilation options for further calls to Compile
+ *
+ * @param rcvr		[in] レシーバ
+ * @param r			[in] Frame with option flags
+ *
+ * @return			Frame representing new compilation mode.
+ */
+
+newtRef NsSetCompileOptions(newtRefArg rcvr, newtRefArg r)
+{
+    if (! NewtRefIsFrame(r))
+        return NewtThrow(kNErrNotAFrame, r);
+
+    newtRefVar nosCompatible = NcGetSlot(r, NSSYM0(nosCompatible));
+    if (NewtRefIsNotNIL(nosCompatible)) {
+        NEWT_MODE_NOS2 = true;
+    }
+    newtRefVar nos1Functions = NcGetSlot(r, NSSYM0(nos1Functions));
+    if (NewtRefIsNotNIL(nos1Functions)) {
+        NEWT_MODE_NOS1_FUNCTIONS = true;
+    }
+
+    return NsGetCompileOptions(rcvr);
+}
+
+
 #if 0
 #pragma mark -
 #endif

--- a/src/newt_core/NewtObj.c
+++ b/src/newt_core/NewtObj.c
@@ -1049,6 +1049,7 @@ bool NewtRefIsImmediate(newtRefArg r)
 
 /*------------------------------------------------------------------------*/
 /** オブジェクトがコードブロック（関数オブジェクト）かチェックする
+ * Fast functions are also CodeBlocks.
  *
  * @param r			[in] オブジェクト
  *
@@ -1065,6 +1066,9 @@ bool NewtRefIsCodeBlock(newtRefArg r)
         klass = NcClassOf(r);
 
         if (NewtRefEqual(klass, NSSYM0(CodeBlock)))
+            return true;
+
+        if (NewtRefEqual(klass, kNewtFastFunctionClass))
             return true;
     }
 
@@ -1144,6 +1148,9 @@ int NewtRefFunctionType(newtRefArg r)
 
         if (NewtRefEqual(klass, NSSYM0(CodeBlock)))
 			return kNewtCodeBlock;
+
+        if (NewtRefEqual(klass, kNewtFastFunctionClass))
+			return kNewtFastFunction;
 
 		if (NewtRefEqual(klass, NSSYM0(_function.native0)))
 			return kNewtNativeFn;
@@ -4125,7 +4132,7 @@ newtRef NewtMakeNativeFn0(void * funcPtr, size_t numArgs, bool indefinite, char 
     fn = NewtMakeFrame2(sizeof(fnv) / (sizeof(newtRefVar) * 2), fnv);
 
     NcSetSlot(fn, NSSYM0(funcPtr), NewtMakeAddress(funcPtr));
-    NcSetSlot(fn, NSSYM0(numArgs), NewtMakeInteger(numArgs));
+    NcSetSlot(fn, NSSYM0(numArgs), MakeFFNumArgs(numArgs, 0));
     NcSetSlot(fn, NSSYM0(indefinite), NewtMakeBoolean(indefinite));
     NcSetSlot(fn, NSSYM0(docString), NSSTRCONST(doc));
 
@@ -4181,7 +4188,7 @@ newtRef NewtMakeNativeFunc0(void * funcPtr, size_t numArgs, bool indefinite, cha
     fn = NewtMakeFrame2(sizeof(fnv) / (sizeof(newtRefVar) * 2), fnv);
 
     NcSetSlot(fn, NSSYM0(funcPtr), NewtMakeAddress(funcPtr));
-    NcSetSlot(fn, NSSYM0(numArgs), NewtMakeInteger(numArgs));
+    NcSetSlot(fn, NSSYM0(numArgs), MakeFFNumArgs(numArgs, 0));
     NcSetSlot(fn, NSSYM0(indefinite), NewtMakeBoolean(indefinite));
     NcSetSlot(fn, NSSYM0(docString), NSSTRCONST(doc));
 

--- a/src/newt_core/NewtParser.c
+++ b/src/newt_core/NewtParser.c
@@ -13,6 +13,7 @@
 /* ヘッダファイル */
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include "NewtParser.h"
 #include "NewtErrs.h"
@@ -219,7 +220,7 @@ newtErr NPSParseFile(const char * path,
 
         if (yyin == NULL)
         {
-            NewtFprintf(stderr, "not open file.\n");
+            NewtFprintf(stderr, "Could not open file %s (errno=%d).\n", path, errno);
             return kNErrFileNotOpen;
         }
 

--- a/src/newt_core/NewtPrint.c
+++ b/src/newt_core/NewtPrint.c
@@ -731,7 +731,7 @@ void NIOPrintFnFrame(newtStream_t * f, newtRefArg r)
     size_t		numArgs;
 	char *		indefiniteStr = "";
 
-    numArgs = NewtRefToInteger(NcGetSlot(r, NSSYM0(numArgs)));
+    numArgs = FFNumArgsToNumArgs(NcGetSlot(r, NSSYM0(numArgs)));
 	indefinite = NcGetSlot(r, NSSYM0(indefinite));
 
 	if (NewtRefIsNotNIL(indefinite))
@@ -840,9 +840,13 @@ void NIOPrintObjFrame(newtStream_t * f, newtRefArg r, int32_t depth, bool litera
 
             slot = NewtGetMapIndex(obj->as.map, i, &index);
 			if (slot == kNewtRefUnbind) break;
-
-            NIOPrintObjSymbol(f, slot);
-            NIOFputs(": ", f);
+            // Special case of fastFunctions maps with NIL slot names
+            if (slot == kNewtRefNIL) {
+                NIOFputs("NIL: ", f);
+            } else {
+                NIOPrintObjSymbol(f, slot);
+                NIOFputs(": ", f);
+            }
             NIOPrintObj2(f, slots[i], depth, literal);
 
         }

--- a/src/newt_core/NewtVM.c
+++ b/src/newt_core/NewtVM.c
@@ -110,6 +110,7 @@ static void			iter_next(newtRefArg iter);
 static bool			iter_done(newtRefArg iter);
 
 static newtRef		NVMMakeArgsArray(uint16_t numArgs);
+static newtRef		NVMMakeFastFunctionArgFrame(newtRefArg fn);
 static void			NVMBindArgs(uint16_t numArgs);
 static void			NVMThrowBC(newtErr err, newtRefArg value, int16_t pop, bool push);
 static newtErr		NVMFuncCheck(newtRefArg fn, int16_t numArgs);
@@ -653,6 +654,42 @@ void NVMNoStackFrameForReturn(void)
     PC = (uint32_t) -1;
 }
 
+/*------------------------------------------------------------------------*/
+/** Build a new arg frame for a fast function that does not have any.
+ *
+ * @return		a new arg frame
+ */
+newtRef NVMMakeFastFunctionArgFrame(newtRefArg fn)
+{
+    uintptr_t fnNumArgs;
+    size_t argFrameSize;
+    newtRefVar argFrameMap;
+    newtRefVar result;
+    size_t argIndex;
+
+    fnNumArgs = NewtRefToInteger(NcGetSlot(fn, NSSYM0(numArgs)));
+    argFrameSize = fnNumArgs + 3;
+
+    argFrameMap = NewtMakeSlotsObj(NewtMakeInteger(0), argFrameSize + 1, 0);
+
+    NewtSlotsSetSlot(argFrameMap, 0, kNewtRefNIL);
+    NewtSlotsSetSlot(argFrameMap, 1, NSSYM0(_nextArgFrame));
+    NewtSlotsSetSlot(argFrameMap, 2, NSSYM0(_parent));
+    NewtSlotsSetSlot(argFrameMap, 3, NSSYM0(_implementor));
+
+    result = NewtMakeFrame(argFrameMap, argFrameSize);
+    NewtSetFrameSlot(result, 0, kNewtRefNIL);
+    NewtSetFrameSlot(result, 1, kNewtRefNIL);
+    NewtSetFrameSlot(result, 2, kNewtRefNIL);
+
+    // Other elements just don't have any name and will be accessed by position.
+    for (argIndex = 0; argIndex < fnNumArgs; argIndex++) {
+         NewtSetArraySlot(argFrameMap, argIndex + 4, kNewtRefNIL);
+         NewtSetFrameSlot(result, argIndex + 3, kNewtRefNIL);
+    }
+
+    return result;
+}
 
 #if 0
 #pragma mark *** 呼出しスタック
@@ -1782,7 +1819,14 @@ void NVMFuncCall(newtRefArg fn, int16_t numArgs)
     PC = 0;					// 5. PC に 0 をセット
 
     // 6. ローカルフレーム（FUNC.argFrame）をクローンして LOCALS にセット
-    LOCALS = NcClone(NcGetSlot(FUNC, NSSYM0(argFrame)));
+    newtRefVar af = NcGetSlot(FUNC, NSSYM0(argFrame));
+    // argFrame can be nil if function does not use any variable from
+    // caller. Just create an argFrame to hold passed arguments
+    if (NewtRefIsNIL(af)) {
+        LOCALS = NVMMakeFastFunctionArgFrame(FUNC);
+    } else {
+        LOCALS = NcClone(af);
+    }
 
     // 7. LOCALS の引数スロットにスタックにある引数をセットする
     //    引数は LOCALS の４番スロットから開始し左から右へ挿入される
@@ -1866,7 +1910,14 @@ void NVMMessageSend(newtRefArg impl, newtRefArg receiver, newtRefArg fn, int16_t
     IMPL = impl;			// 7. IMPL IMPL implementor をセット
 
     // 8. ローカルフレーム（FUNC.argFrame）をクローンして LOCALS にセット
-    LOCALS = NcClone(NcGetSlot(FUNC, NSSYM0(argFrame)));
+    newtRefVar af = NcGetSlot(FUNC, NSSYM0(argFrame));
+    // argFrame can be nil if function does not use any variable from
+    // caller. Just create an argFrame to hold passed arguments
+    if (NewtRefIsNIL(af)) {
+        LOCALS = NVMMakeFastFunctionArgFrame(FUNC);
+    } else {
+        LOCALS = NcClone(af);
+    }
 
     // 9. RCVR を LOCALS._parent にセット
     NcSetSlot(LOCALS, NSSYM0(_parent), RCVR);
@@ -2063,9 +2114,9 @@ void si_pushself(void)
 void si_set_lex_scope(void)
 {
     newtRefVar	fn;
-    newtRefVar	af;
     int type;
 
+    uint32_t pc = PC;
     fn = stk_pop();
     type = NewtRefFunctionType(fn);
     if (type == kNewtNotFunction) {
@@ -2074,10 +2125,19 @@ void si_set_lex_scope(void)
     if (type != kNewtNativeFn && type != kNewtNativeFunc)
     {
         fn = NcClone(fn);
-        af = NcClone(NcGetSlot(fn, NSSYM0(argFrame)));
-        NcSetSlot(af, NSSYM0(_nextArgFrame), LOCALS);
-        NcSetSlot(af, NSSYM0(_parent), RCVR);
-        NcSetSlot(af, NSSYM0(_implementor), IMPL);
+        newtRefVar	af = NcGetSlot(fn, NSSYM0(argFrame));
+        if (NewtRefIsNIL(af)) {
+            // We can have a si_set_lex_scope for a function with no argFrame.
+            // Create a dummy one.
+            af = NVMMakeFastFunctionArgFrame(fn);
+        } else if (NewtRefIsFrame(af)) {
+            af = NcClone(af);
+            NcSetSlot(af, NSSYM0(_nextArgFrame), LOCALS);
+            NcSetSlot(af, NSSYM0(_parent), RCVR);
+            NcSetSlot(af, NSSYM0(_implementor), IMPL);
+        } else {
+            return stk_push(NVMThrow(kNErrNotAFunction, fn));
+        }
         NcSetSlot(fn, NSSYM0(argFrame), af);
     }
     stk_push(fn);

--- a/src/newt_core/incs/NewtEnv.h
+++ b/src/newt_core/incs/NewtEnv.h
@@ -30,6 +30,7 @@
 #define NEWT_SWEEP			(newt_env.sweep)				///< SWEEPフラグ
 #define NEWT_NEEDGC			(newt_env.needgc)				///< GCフラグ
 #define NEWT_MODE_NOS2		(newt_env.mode.nos2)			///< NOS2 コンパチブル
+#define NEWT_MODE_NOS1_FUNCTIONS	(newt_env.mode.nos1Functions)	///< As opposed to NewtonOS 2.x-only faster functions
 
 #define NSSTR(s)			(NewtMakeString(s, false))		///< 文字列オブジェクトの作成
 #define NSSTRCONST(s)		(NewtMakeString(s, true))		///< 文字列定数オブジェクトの作成
@@ -87,6 +88,7 @@ typedef struct {
 
 	/// モード
 	struct {
+		bool	nos1Functions;	///< As opposed to NewtonOS 2.x-only faster functions
 		bool	nos2;			///< NOS2 コンパチブル
 	} mode;
 
@@ -218,6 +220,10 @@ typedef struct {
 	// ENV
     newtRefVar	_ENV_;				///< _ENV_
     newtRefVar	NEWTLIB;			///< NEWTLIB
+
+	// Compile options
+    newtRefVar	nosCompatible;		///< nosCompatible
+    newtRefVar	nos1Functions;		///< nos1Functions
 
 	// ARGV
     newtRefVar	_ARGV_;				///< _ARGV_

--- a/src/newt_core/incs/NewtFns.h
+++ b/src/newt_core/incs/NewtFns.h
@@ -160,6 +160,8 @@ newtRef		NsExit(newtRefArg rcvr, newtRefArg r);
 
 newtRef		NsCompile(newtRefArg rcvr, newtRefArg r);
 newtRef		NsGetEnv(newtRefArg rcvr, newtRefArg r);
+newtRef		NsGetCompileOptions(newtRefArg rcvr);
+newtRef		NsSetCompileOptions(newtRefArg rcvr, newtRefArg r);
 
 newtRef		NsBinEqual(newtRefArg rcvr, newtRefArg a, newtRefArg b);
 newtRef		NsExtractByte(newtRefArg rcvr, newtRefArg r, newtRefArg offset);

--- a/src/newt_core/incs/NewtObj.h
+++ b/src/newt_core/incs/NewtObj.h
@@ -16,7 +16,7 @@
 
 /* ヘッダファイル */
 #include "NewtType.h"
-
+#include <sys/types.h>
 
 /* マクロ */
 /// addr <--> integer　時のシフト
@@ -38,6 +38,7 @@
 
 #define	NewtRefIsSpecial(r)			((r & 0xF) == 2)					///< 特殊オブジェクトか？
 #define	NewtRefToSpecial(r)			(int32_t)((uintptr_t)r >> 2)			///< オブジェクト参照を特殊値に変換
+#define	NewtRefMakeSpecial(v)		(newtRef)(((uintptr_t)(v) << 4) | 2)	///< 特殊オブジェクトを作成
 
 #define NewtRefIsMagicPointer(r)	((r & 3) == 3)										///< マジックポインタか？（数値および名前付）
 
@@ -105,12 +106,20 @@
 #define NewtMakeNativeFunc(funcPtr, numArgs, doc)		NewtMakeNativeFunc0(funcPtr, numArgs, false, doc)	
 #define NewtDefGlobalFunc(sym, funcPtr, numArgs, doc)	NewtDefGlobalFunc0(sym, funcPtr, numArgs, false, doc)	
 
+#define FFNumArgsToLocals(i)		(NewtRefToInt30(i) >> 16)
+#define FFNumArgsToNumArgs(i)		(NewtRefToInt30(i) & 0xFFFF)
+#define MakeFFNumArgs(n, l)			NewtMakeInt30(n | (l << 16))
+
+// C++ Headers mention the possibility of more classes:
+// const Ref	kFuncClass = MAKEIMMED(kImmedSpecial, 3);			// Actually encompasses xxxxxx32
+#define kNewtFastFunctionClass		NewtRefMakeSpecial(3)
 
 /* 定数 */
 
 enum {
 	kNewtNotFunction			= 0,
 	kNewtCodeBlock,						// バイトコード関数
+	kNewtFastFunction,					// NewtonOS 2.x functions
 	kNewtNativeFn,						// ネイティブ関数（rcvrなし、old style）
 	kNewtNativeFunc						// ネイティブ関数（rcvrあり、new style）
 };

--- a/src/parser/newt.y
+++ b/src/parser/newt.y
@@ -307,7 +307,7 @@ array
 		;
 
 array_item_list
-		: /* empty */					{ $$ = NPSMakeArray(kNewtRefUnbind); }
+		: /* empty */					{ $$ = NPSMakeArray(NSSYM0(array)); }
 		| object						{ $$ = NPSMakeArray($1); }
 		| array_item_list ','
 		| array_item_list ',' object	{ $$ = NPSAddArraySlot($1, $3); }
@@ -339,7 +339,7 @@ binary_item_list
 constructor
 		// 配列の生成
 		: '[' kSYMBOL ':' expr_list ']'		{ $$ = NPSGenNode2(kNPSMakeArray, $2, $4); }
-		| '[' expr_list ']'					{ $$ = NPSGenNode2(kNPSMakeArray, kNewtRefUnbind, $2); }
+		| '[' expr_list ']'					{ $$ = NPSGenNode2(kNPSMakeArray, NSSYM0(array), $2); }
 
 		// フレームの生成
 		| '{' frame_constructor_list '}'	{ $$ = NPSGenNode1(kNPSMakeFrame, $2); }

--- a/src/version.h
+++ b/src/version.h
@@ -40,6 +40,7 @@
 						"  -v              print version number\n"		\
 						"  -h              print this help message\n"	\
 						"  --newton,--nos2 Newton OS 2.0 compatible	\n"	\
+						"  --nos1Functions Newton OS 1.x functions\n"	\
 						"  --copyright     print copyright\n"			\
 						"  --version       print version number\n"		\
 						"  --staff         list of developers\n"

--- a/tests/test_common.newt
+++ b/tests/test_common.newt
@@ -23,6 +23,8 @@ begin
 end;
 
 global protoTestCase := {
+    SetUp: func() nil,
+    TearDown: func() nil,
     Run: func()
     begin
         local finalResult := true;
@@ -41,7 +43,9 @@ global protoTestCase := {
                 local resultStr := "OK";
                 local failedException := nil;
                 try
+                    :SetUp();
                     Perform(self, k, []);
+                    :TearDown();
                 onexception |evt.ex.test| do
                 begin
                     resultStr := "FAILED";

--- a/tests/test_compile.newt
+++ b/tests/test_compile.newt
@@ -12,8 +12,11 @@ end;
 local testCases := [
     {
         _proto: protoTestCase,
+        SetUp: func()
+            SetCompileOptions({nos1Functions: nil, nosCompatible: true}),
         testCompileReturnNil: func() begin
             local f := Compile("return nil");
+            :AssertNotEqual(f.class, 'CodeBlock);   // There is no MakeSpecial/MakeImmed yet
             :AssertEqual(f.numArgs, 0);
             :AssertEqual(f.instructions, MakeBinaryFromHex("220202", 'instructions));
         end,
@@ -32,6 +35,33 @@ local testCases := [
         testExpressionValueWithUnusedLocal: func() begin
             local f := Compile("local a := true; 1");
             :AssertEqual(f.instructions, MakeBinaryFromHex("27001AA32402", 'instructions));
+            :AssertEqual(f.literals, NIL);
+        end,
+        testClosure: func() begin
+            local f := Compile("local f := func() return a; local a := 1; f");
+            :AssertEqual(f.instructions, MakeBinaryFromHex("1804A324A47B02", 'instructions));
+                // NewtonOS 2.1 compiler:
+                // Optimizes the number of local variables to 1
+                // 0 : 18        push (b=0)
+                // 1 : 04        set-lex-scope
+                // 2 : A3        set-var (b=3)
+                // 7 : 24        push-constant (b=4) (int=1)
+                // 6 : A9        find-and-set-var (b=1)
+                // 27: 7B        get-var (b=3)
+                // 8 : 02        return
+                // NEWT/0
+                // 0 : 18        push (b=0)
+                // 1 : 04        set-lex-scope
+                // 2 : A3        set-var (b=3)
+                // 7 : 24        push-constant (b=4) (int=1)
+                // 6 : A4        set-var (b=4)  // optimization of using set-var instead of find-and-set-var
+                // 27: 7B        get-var (b=3)
+                // 8 : 02        return
+            :AssertEqual(Length(f.literals), 1);
+            local f0 := f.literals[0];
+            :AssertEqual(f0.literals[0], 'a);
+            :AssertTrue(IsFrame(f0.argFrame));
+            :AssertEqual(3, Length(f0.argFrame));
         end,
         testTryWithOnException: func() begin
             local f := Compile("try 1 onexception |evt| do 2");
@@ -137,6 +167,52 @@ local testCases := [
                 // 7 : 18        push (b=0)
                 // 8 : 2A        call (b=2)
                 // 9 : 02        return
+        end,
+        testSubfunction: func() begin
+            local f0 := Compile("func f(x, y) [x, y]; f(1, 2)");
+            :AssertEqual(f0.literals[0], 'f);
+            :AssertTrue(IsFunction(f0.literals[1]));
+            :AssertEqual(f0.literals[2], 'DefGlobalFn);
+            :AssertEqual(f0.argFrame, nil);
+            local f := f0.literals[1];
+            :AssertEqual(Length(f.literals), 1);
+            :AssertEqual(f.literals[0], 'Array);
+            :AssertEqual(f.argFrame, nil);
+            :AssertEqual(f.instructions, MakeBinaryFromHex(
+                "7B7C188A02",
+                'instructions));
+                // NewtonOS 2.1 compiler:
+                // 0 : 7B        get-var (b=3)
+                // 1 : 7C        get-var (b=4)
+                // 2 : 18        push (b=0)
+                // 3 : 8A        make-array (b = 2)
+                // 11: 02        return
+            :AssertEqual(f0.instructions, MakeBinaryFromHex(
+                "18191A2A0024270008182A02",
+                'instructions));
+                // NewtonOS 2.1 compiler:
+                // 0 : 18        push (b=0)
+                // 1 : 19        push (b=1)
+                // 2 : 1A        push (b=2)
+                // 3 : 2A        call (b=2)
+                // 4 : 00        pop
+                // 5 : 24        push-constant (b=4) (int=1)
+                // 6 : 270008    push-constant (b=8) (int=2)
+                // 7 : 18        push (b=0)
+                // 8 : 2A        call (b=2)
+                // 9 : 02        return
+        end,
+    },
+    // NOS 1.x compatible tests (without fast functions)
+    {
+        _proto: protoTestCase,
+        SetUp: func()
+            SetCompileOptions({nos1Functions: true, nosCompatible: true}),
+        testNOS1CompileReturnNil: func() begin
+            local f := Compile("return nil");
+            :AssertEqual(f.class, 'CodeBlock);
+            :AssertEqual(f.numArgs, 0);
+            :AssertEqual(f.instructions, MakeBinaryFromHex("220202", 'instructions));
         end,
     }
 ];

--- a/tests/test_compile.newt
+++ b/tests/test_compile.newt
@@ -145,7 +145,7 @@ local finalResult := true;
 
 foreach tc in testCases do
 begin
-    finalResult := finalResult && tc:Run();
+    finalResult := finalResult and tc:Run();
 end;
 
 if not finalResult then Exit(1);

--- a/tests/test_compile.newt
+++ b/tests/test_compile.newt
@@ -1,0 +1,151 @@
+#!newt
+
+if not load("test_common.newt") then
+begin
+    Print("Could not load test_common.newt\n");
+    Exit(1);
+end;
+
+// These test cases were compared with NewtonOS compiler.
+// In some cases, NEWT/0 does not generate exactly the same bytecode, which is
+// fine as long as the behavior is the same.
+local testCases := [
+    {
+        _proto: protoTestCase,
+        testCompileReturnNil: func() begin
+            local f := Compile("return nil");
+            :AssertEqual(f.numArgs, 0);
+            :AssertEqual(f.instructions, MakeBinaryFromHex("220202", 'instructions));
+        end,
+        testCompileReturnTrue: func() begin
+            local f := Compile("return true");
+            :AssertEqual(f.instructions, MakeBinaryFromHex("27001A0202", 'instructions));
+        end,
+        testCompileUnusedLocal: func() begin
+            local f := Compile("local a := true; return nil");
+            :AssertEqual(f.instructions, MakeBinaryFromHex("27001AA3220202", 'instructions));
+        end,
+        testExpressionValue: func() begin
+            local f := Compile("nil");
+            :AssertEqual(f.instructions, MakeBinaryFromHex("2202", 'instructions));
+        end,
+        testExpressionValueWithUnusedLocal: func() begin
+            local f := Compile("local a := true; 1");
+            :AssertEqual(f.instructions, MakeBinaryFromHex("27001AA32402", 'instructions));
+        end,
+        testTryWithOnException: func() begin
+            local f := Compile("try 1 onexception |evt| do 2");
+            :AssertEqual(f.literals[0], 'evt);
+            :AssertEqual(f.instructions, MakeBinaryFromHex(
+                "18270030C9240700075F001227000807000702",
+                'instructions));
+                // Identical to NewtonOS 2.1 compiler:
+                // 0 : 18        push (b=0)
+                // 1 : 270030    push-constant (b=48) (int=12)
+                // 4 : C9        new-handlers
+                // 5 : 24        push-constant (b=4) (int=1)
+                // 6 : 070007    pop-handlers
+                // 9 : 5F0012    branch (b=18 vs b=21???)
+                // 12: 270008    push-constant (b=8) (int=2)
+                // 15: 070007    pop-handlers
+                // 18: 02        return
+        end,
+        testTryWithOnExceptionAndReturn: func() begin
+            // https://github.com/gnue/NEWT0/issues/7
+            local f := Compile("try Throw('|evt.ex|, 1); onexception |evt.ex| do return 2; return 3;");
+            :AssertEqual(f.literals[0], '|evt.ex|);
+            :AssertEqual(f.literals[1], 'Throw);
+            :AssertEqual(f.instructions, MakeBinaryFromHex(
+                   "18270040C91824192A000700075F00172700080207000727000C0202",
+                'instructions));
+                // "18270040C91824192A000700075F0018270008020007000727000C0202",
+                // NewtonOS 2.1 compiler:
+                // 0 : 18        push (b=0)
+                // 1 : 270040    push-constant (b=64) (int=16)
+                // 4 : C9        new-handlers
+                // 5 : 18        push (b=0)
+                // 6 : 24        push-constant (b=4) (int=1)
+                // 7 : 19        push (b=1)
+                // 8 : 2A        call (b=2)
+                // 9 : 00        pop
+                // 10: 070007    pop-handlers
+                // 13: 5F0018    branch (b=24)
+                // 16: 270008    push-constant (b=8) (int=2)
+                // 19: 02        return
+                // 20: 00        pop            // useless pop, that we don't encode
+                // 21: 070007    pop-handlers
+                // 24: 27000C    push-constant (b=12) (int=3)
+                // 27: 02        return
+                // 28: 02        return         // useless second return
+        end,
+        testTryWithOnExceptionAndAssign: func() begin
+            local f := Compile("local r := 1; try Throw('|evt.ex|, 2); onexception |evt.ex| do r := 3; r");
+            :AssertEqual(f.literals[0], '|evt.ex|);
+            :AssertEqual(f.literals[1], 'Throw);
+            :AssertEqual(f.instructions, MakeBinaryFromHex(
+                "24A318270050C918270008192A000700075F001B27000CA30700077B02",
+                'instructions));
+                // NewtonOS 2.1 compiler:
+                // 0 : 24        push-constant (b=4) (int=1)
+                // 1 : A3        set-var (b=3)
+                // 2 : 18        push (b=0)
+                // 3 : 270050    push-constant (b=80) (int=20)
+                // 6 : C9        new-handlers (b=1)
+                // 7 : 18        push (b=0)
+                // 8 : 270008    push-constant (b=8) (int=2)
+                // 11: 19        push (b=1)
+                // 12: 2A        call (b=2)
+                // 13: 00        pop
+                // 14: 070007    pop-handlers
+                // 17: 5F001B    branch (b=27)
+                // 20: 27000C    push-constant (b=12) (int=3)
+                // 23: A3        set-var (b=3)
+                // 24: 070007    pop-handlers
+                // 27: 7B        get-var (b=3)
+                // 28: 02        return
+        end,
+        testNoVariableIsCreatedForParameters: func() begin
+            local f0 := Compile("func f(x, y) [x, y]; f(1, 2)");
+            :AssertEqual(f0.literals[0], 'f);
+            :AssertTrue(IsFunction(f0.literals[1]));
+            :AssertEqual(f0.literals[2], 'DefGlobalFn);
+            :AssertEqual(f0.argFrame, nil);
+            local f := f0.literals[1];
+            :AssertEqual(Length(f.literals), 1);
+            :AssertEqual(f.literals[0], 'Array);
+            :AssertEqual(f.argFrame, nil);
+            :AssertEqual(f.instructions, MakeBinaryFromHex(
+                "7B7C188A02",
+                'instructions));
+                // NewtonOS 2.1 compiler:
+                // 0 : 7B        get-var (b=3)
+                // 1 : 7C        get-var (b=4)
+                // 2 : 18        push (b=0)
+                // 3 : 8A        make-array (b = 2)
+                // 11: 02        return
+            :AssertEqual(f0.instructions, MakeBinaryFromHex(
+                "18191A2A0024270008182A02",
+                'instructions));
+                // NewtonOS 2.1 compiler:
+                // 0 : 18        push (b=0)
+                // 1 : 19        push (b=1)
+                // 2 : 1A        push (b=2)
+                // 3 : 2A        call (b=2)
+                // 4 : 00        pop
+                // 5 : 24        push-constant (b=4) (int=1)
+                // 6 : 270008    push-constant (b=8) (int=2)
+                // 7 : 18        push (b=0)
+                // 8 : 2A        call (b=2)
+                // 9 : 02        return
+        end,
+    }
+];
+
+local finalResult := true;
+
+foreach tc in testCases do
+begin
+    finalResult := finalResult && tc:Run();
+end;
+
+if not finalResult then Exit(1);


### PR DESCRIPTION
New series of tests that compare the code generated by NewtonOS compiler with
NEWT/0.
Add several optimizations.
Add (partial) fast function optimization following NewtonOS 2.x
Fix the class of bytecode instructions.
Fix the class of arrays.