### PR TITLE
Fix typo with evt.ex.msg exceptions

### DIFF
--- a/src/newt_core/NewtEnv.c
+++ b/src/newt_core/NewtEnv.c
@@ -178,7 +178,7 @@ void NewtInitSYM(void)
 
     // exception type
     INITSYM(type.ref);
-    INITSYM(ext.ex.msg);
+    INITSYM(evt.ex.msg);
 
     // exception frame
     INITSYM(name);

--- a/src/newt_core/NewtVM.c
+++ b/src/newt_core/NewtVM.c
@@ -471,7 +471,7 @@ newtRef NVMMakeExceptionFrame(newtRefArg name, newtRefArg data)
 
     if (NewtHasSubclass(name, NSSYM0(type.ref)))
         NcSetSlot(r, NSSYM0(data), data);
-    else if (NewtHasSubclass(name, NSSYM0(ext.ex.msg)))
+    else if (NewtHasSubclass(name, NSSYM0(evt.ex.msg)))
         NcSetSlot(r, NSSYM0(message), data);
     else
         NcSetSlot(r, NSSYM0(error), data);

--- a/src/newt_core/incs/NewtEnv.h
+++ b/src/newt_core/incs/NewtEnv.h
@@ -175,13 +175,13 @@ typedef struct {
         newtRefVar	ref;			///< type.ref
     } type;
 
-	/// ext
+	/// evt
     struct {
-		/// ext.ex
+		/// evt.ex
         struct {
-            newtRefVar	msg;		///< ext.ex.msg
+            newtRefVar	msg;		///< evt.ex.msg
         } ex;
-    } ext;
+    } evt;
 
     newtRefVar	name;				///< name
     newtRefVar	data;				///< data

--- a/tests/test_exceptions.newt
+++ b/tests/test_exceptions.newt
@@ -42,6 +42,26 @@ local testCases := [
                 result
             end)
         end,
+        testCatchCustomWithError: func() begin
+            :AssertEqual(-42, begin
+                local result := nil;
+                try
+                    Throw('|evt.ex.foo|, -42)
+                onexception |evt.ex.foo| do
+                    result := CurrentException().error;
+                result
+            end)
+        end,
+        testCatchCustomWithMessage: func() begin
+            :AssertEqual("error", begin
+                local result := nil;
+                try
+                    Throw('|evt.ex.msg.foo|, "error")
+                onexception |evt.ex.msg| do
+                    result := CurrentException().message;
+                result
+            end)
+        end,
         testCatchCustomWithString: func() begin
             :AssertEqual("Some data", begin
                 local result := nil;


### PR DESCRIPTION
Exceptions with messages have prefix evt.ex.msg, not ext.ex.msg.
See NewtonScript Programming Language, page 3-17.
Also add test for error slot, typically used when Throw is passed an integer.