### PR TITLE
Add CObjects for garbage collection aware native (C) objects

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -241,6 +241,8 @@ test:
 	$(NEWT) -C tests test_arithmetic.newt
 	$(NEWT) -C tests test_compile.newt
 	$(NEWT) -C tests test_exceptions.newt
+	test "x@MAKE_EXT@" = x || $(NEWT) -C tests test_protoFILE.newt
+	test "x@MAKE_EXT@" = x || $(NEWT) -C tests test_protoREGEX.newt
 
 
 ### CLEAN

--- a/src/newt_core/NewtEnv.c
+++ b/src/newt_core/NewtEnv.c
@@ -151,6 +151,7 @@ void NewtInitSYM(void)
     INITSYM(bits);
     INITSYM(cbits);
     INITSYM(nativeModule);
+    INITSYM(CObject);
 
     // for loop
     INITSYM(collect);

--- a/src/newt_core/incs/NewtEnv.h
+++ b/src/newt_core/incs/NewtEnv.h
@@ -145,6 +145,7 @@ typedef struct {
     newtRefVar	bits;			///< bits
     newtRefVar	cbits;			///< cbits
     newtRefVar	nativeModule;			///< NTKC native module
+    newtRefVar	CObject;			///< GC-aware CObjects
 
     // for loop
     newtRefVar	collect;			///< collect

--- a/src/newt_core/incs/NewtObj.h
+++ b/src/newt_core/incs/NewtObj.h
@@ -80,6 +80,7 @@
 #define	NewtObjIsSlotted(v)			((v->header.h & kNewtObjSlotted) != 0)  ///< オブジェクトデータがスロットか？
 #define	NewtObjIsArray(v)			(NewtObjType(v) == 1)					///< オブジェクトデータが配列か？
 #define	NewtObjIsFrame(v)			(NewtObjType(v) == 3)					///< オブジェクトデータがフレームか？
+#define	NewtObjIsIndirectBinary(v)	(NewtObjType(v) == kNewtObjIndirectBin)	///< Indirect binaries special value
 #define NewtObjIsLiteral(v)			((v->header.h & kNewtObjLiteral) == kNewtObjLiteral)		///< リテラルか？
 #define NewtObjIsSweep(v, mark)		(((v->header.h & kNewtObjSweep) == kNewtObjSweep) == mark)  ///< スウィープ対象か？
 #define	NewtObjSize(v)				(v->header.h >> 8)					///< オブジェクトデータのサイズを取得
@@ -181,6 +182,9 @@ void *		NewtRefToAddress(newtRefArg r);
 
 newtRef		NewtMakeBinary(newtRefArg klass, uint8_t * data, size_t size, bool literal);
 newtRef		NewtMakeBinaryFromHex(newtRefArg klass, const char *hex, bool literal);
+newtRef		NewtAllocCObjectBinary(void* cObj, newtCObjectBinaryProc dtor, newtCObjectBinaryProc marker);
+bool		NewtGetCObjectPtr(newtRefArg bin, void** ptr);
+void		NewtFreeCObject(newtRefArg bin);
 newtRef		NewtMakeSymbol(const char *s);
 newtRef		NewtMakeString(const char *s, bool literal);
 newtRef		NewtMakeString2(const char *s, size_t len, bool literal);

--- a/src/newt_core/incs/NewtObj.h
+++ b/src/newt_core/incs/NewtObj.h
@@ -43,22 +43,25 @@
 #define NewtRefIsMagicPointer(r)	((r & 3) == 3)										///< マジックポインタか？（数値および名前付）
 
 // On 32 bits platform, we use the highest bit, which may be a problem.
-// On 64 bits platform, we assume MIN_ALIGN is 16 and use a low bit.
+// On 64 bits platform, we assume MIN_ALIGN is 16 and use a low bit to store the highest bit.
 #ifdef __NAMED_MAGIC_POINTER__
+#	define NewtMakeNamedMP(r)		NewtSymbolToMP(NewtMakeSymbol(r))					///< 名前付マジックポインタを作成
 #if INTPTR_MAX == INT32_MAX
 #	define NewtRefIsNamedMP(r)		((r & 0x80000003) == 0x80000003)					///< 名前付マジックポインタか？
-#	define NewtMakeNamedMP(r)		NewtSymbolToMP(NewtMakeSymbol(r))					///< 名前付マジックポインタを作成
 #	define NewtMPToSymbol(r)		((newtRef)((((uintptr_t)r << 1) & 0xFFFFFFF8) | 1))	///< 名前付マジックポインタをシンボルに変換
 #	define NewtSymbolToMP(r)		((newtRef)(((uintptr_t)r >> 1) | 0x80000003))		///< シンボルを名前付マジックポインタに変換
 #else
-#	define NewtRefIsNamedMP(r)		((r & 0x7) == 0x7)	///< 名前付マジックポインタか？
-#	define NewtMakeNamedMP(r)		NewtSymbolToMP(NewtMakeSymbol(r))					///< 名前付マジックポインタを作成
-#	define NewtMPToSymbol(r)		((newtRef)((((uintptr_t)r << 1) & 0xFFFFFFFFFFFFFFF0) | 1))	///< 名前付マジックポインタをシンボルに変換
-#	define NewtSymbolToMP(r)		((newtRef)(((uintptr_t)r >> 1) | 0x7))		///< シンボルを名前付マジックポインタに変換
+#	define NewtRefIsNamedMP(r)		((r & 0x8000000000000003) == 0x8000000000000003)	///< 名前付マジックポインタか？
+#	define NewtMPToSymbol(r)		((newtRef)((((uintptr_t)r << 1) & 0x7FFFFFFFFFFFFFF8) | ((((uintptr_t)r & 4) << 61)) | 1))
+#	define NewtSymbolToMP(r)		((newtRef)(((uintptr_t)r >> 1) | (((uintptr_t)r & 0x8000000000000000) >> 61) | 0x8000000000000003))
 #endif
 #endif /* __NAMED_MAGIC_POINTER__ */
 
+#if INTPTR_MAX == INT32_MAX
 #define NewtRefIsNumberedMP(r)		((r & 0x80000003) == 3)								///< 数値マジックポインタか？
+#else
+#define NewtRefIsNumberedMP(r)		((r & 0x8000000000000003) == 3)								///< 数値マジックポインタか？
+#endif
 #define NewtMakeMagicPointer(t, i)	((newtRef)((t << 14) | ((i & 0x03ff) << 2) | 3))	///< マジックポインタを作成
 #define	NewtMPToTable(r)			((int32_t)((uintptr_t)r >> 14))						///< マジックポインタのテーブル番号を取得
 #define	NewtMPToIndex(r)			((int32_t)(((uintptr_t)r >> 2) & 0x03ff))			///< マジックポインタのインデックスを取得

--- a/src/newt_core/incs/NewtType.h
+++ b/src/newt_core/incs/NewtType.h
@@ -71,6 +71,9 @@ enum {
 enum {
     kNewtObjSlotted		= 0x01,		///< スロット
     kNewtObjFrame		= 0x02,		///< フレーム
+    // If set, object is a frame. Cannot be set unless kObjSlotted is also set.
+    // Actually, we have indirect binaries with type equal to 0x02, probably a NewtonOS 2 addition.
+    kNewtObjIndirectBin	= 0x02,
 
     kNewtObjLiteral		= 0x40,		///< リテラル
     kNewtObjSweep		= 0x80		///< ゴミ掃除（GC用）
@@ -153,6 +156,16 @@ typedef struct newtObj {
     } as;
 } newtObj;
 
+
+// CObjects
+typedef void (*newtCObjectBinaryProc)(void*);
+/// Structure for CObjects which embed pointers that can be garbage collected.
+/// Mimics NewtonOS CObjects
+typedef struct newtCObject {
+	void*					cObj;	///< Embedded pointer
+	newtCObjectBinaryProc	dtor;	///< Destructor
+	newtCObjectBinaryProc	marker;	///< Marker function, or NULL. Should mark reachable objects during garbage collection.
+} newtCObject;
 
 /// シンボルデータ
 typedef struct {

--- a/tests/test_common.newt
+++ b/tests/test_common.newt
@@ -89,6 +89,14 @@ global protoTestCase := {
             Throw('|evt.ex.test.assertEqualDeltaFailed|, {x: x, y: y, delta: delta})
         end;
     end,
+
+    AssertLessThan: func(x, y)
+    begin
+        if not x < y then
+        begin
+            Throw('|evt.ex.test.AssertLessThanFailed|, {x: x, y: y})
+        end;
+    end,
     
     AssertThrow: func(sym, closure)
     begin

--- a/tests/test_protoFILE.newt
+++ b/tests/test_protoFILE.newt
@@ -1,0 +1,55 @@
+#!newt
+
+if not load("test_common.newt") then
+begin
+    Print("Could not load test_common.newt\n");
+    Exit(1);
+end;
+
+local testCases := [
+    {
+        _proto: protoTestCase,
+        testRequire: func() begin
+            Require("protoFILE");
+        end,
+        testOpen: func() begin
+            Require("protoFILE");
+            local f := {
+                _proto: @protoFILE,
+            };
+            f:Open("/dev/null", "w");
+            local r := f:Close();
+            :AssertEqual(r, 0);
+        end,
+        testGC: func() begin
+            Require("protoFILE");
+            local f := {
+                _proto: @protoFILE,
+            };
+            f:Open("/dev/null", "w");
+            local fn := f:Fileno();
+            local maxFileno := fn;
+            for i := 0 to 64 do
+            begin
+                local g := {
+                    _proto: @protoFILE,
+                };
+                g:Open("/dev/null", "w");
+                local gn := g:Fileno();
+                if (gn > maxFileno) then
+                    maxFileno := gn;
+            end;
+            // Force a garbage collect by looping...
+            for i := 0 to 200 do
+                f:Fileno();
+            local h := {
+                _proto: @protoFILE,
+            };
+            h:Open("/dev/null", "w");
+            local hn := h:Fileno();
+            :AssertTrue(hn < maxFileno);
+        end,
+    }
+];
+
+RunTestCases(testCases);

--- a/tests/test_protoFILE.newt
+++ b/tests/test_protoFILE.newt
@@ -52,4 +52,11 @@ local testCases := [
     }
 ];
 
-RunTestCases(testCases);
+local finalResult := true;
+
+foreach tc in testCases do
+begin
+    finalResult := finalResult and tc:Run();
+end;
+
+if not finalResult then Exit(1);

--- a/tests/test_protoFILE.newt
+++ b/tests/test_protoFILE.newt
@@ -29,7 +29,7 @@ local testCases := [
             f:Open("/dev/null", "w");
             local fn := f:Fileno();
             local maxFileno := fn;
-            for i := 0 to 64 do
+            for i := 0 to 128 do
             begin
                 local g := {
                     _proto: @protoFILE,
@@ -47,7 +47,7 @@ local testCases := [
             };
             h:Open("/dev/null", "w");
             local hn := h:Fileno();
-            :AssertTrue(hn < maxFileno);
+            :AssertLessThan(hn, maxFileno);
         end,
     }
 ];

--- a/tests/test_protoREGEX.newt
+++ b/tests/test_protoREGEX.newt
@@ -23,4 +23,11 @@ local testCases := [
     }
 ];
 
-RunTestCases(testCases);
+local finalResult := true;
+
+foreach tc in testCases do
+begin
+    finalResult := finalResult and tc:Run();
+end;
+
+if not finalResult then Exit(1);

--- a/tests/test_protoREGEX.newt
+++ b/tests/test_protoREGEX.newt
@@ -1,0 +1,26 @@
+#!newt
+
+if not load("test_common.newt") then
+begin
+    Print("Could not load test_common.newt\n");
+    Exit(1);
+end;
+
+local testCases := [
+    {
+        _proto: protoTestCase,
+        testRequire: func() begin
+            Require("protoREGEX");
+        end,
+        testMatch: func() begin
+            Require("protoREGEX");
+            local re := /([a-zA-Z]+)([0-9]*)/;
+            local matches := re:match("foo123");
+            :AssertNotNIL(matches);
+            :AssertEqual("123", matches[2]);
+            :AssertEqual("foo", matches[1]);
+        end,
+    }
+];
+
+RunTestCases(testCases);


### PR DESCRIPTION
Following NewtonOS, add CObjects as special binaries that contain a
pointer to a destructor and a marker function.
Add use of CObjects for protoFILE and protoREGEX, fixing a memory leak.
Added tests for protoFILE and protoREGEX, including a protoFILE test
that demonstrates CObjects are garbage collected.