### PR TITLE
Add const where appropriate

### DIFF
--- a/src/newt_core/NewtNSOF.c
+++ b/src/newt_core/NewtNSOF.c
@@ -1180,14 +1180,14 @@ newtRef NSOFReadNSOF(nsof_stream_t * nsof)
  * @return			オブジェクト
  */
 
-newtRef NewtReadNSOF(uint8_t * data, size_t size)
+newtRef NewtReadNSOF(const uint8_t * data, size_t size)
 {
 	nsof_stream_t	nsof;
-	newtRefVar		reault;
+	newtRefVar		result;
 
 	memset(&nsof, 0, sizeof(nsof));
 
-	nsof.data = data;
+	nsof.data = (uint8_t*) data;
 	nsof.len = size;
 	nsof.precedents = NewtMakeArray(kNewtRefUnbind, 0);
 	nsof.verno = NSOFReadByte(&nsof);
@@ -1208,14 +1208,14 @@ newtRef NewtReadNSOF(uint8_t * data, size_t size)
 	}
 #endif /* HAVE_LIBICONV */
 
-	reault = NSOFReadNSOF(&nsof);
+	result = NSOFReadNSOF(&nsof);
 
 #ifdef HAVE_LIBICONV
 	if (nsof.cd.from.utf16be != (iconv_t)-1) iconv_close(nsof.cd.from.utf16be);
 	if (nsof.cd.from.macroman != (iconv_t)-1) iconv_close(nsof.cd.from.macroman);
 #endif /* HAVE_LIBICONV */
 
-	return reault;
+	return result;
 }
 
 

--- a/src/newt_core/NewtObj.c
+++ b/src/newt_core/NewtObj.c
@@ -1219,7 +1219,7 @@ void * NewtRefToAddress(newtRefArg r)
  * @return			バイナリオブジェクト
  */
 
-newtRef NewtMakeBinary(newtRefArg klass, uint8_t * data, size_t size, bool literal)
+newtRef NewtMakeBinary(newtRefArg klass, const uint8_t * data, size_t size, bool literal)
 {
     newtObjRef	obj;
 

--- a/src/newt_core/NewtObj.c
+++ b/src/newt_core/NewtObj.c
@@ -48,9 +48,9 @@ static void			NewtObjRemoveArraySlot(newtObjRef obj, size_t n);
 static void			NewtDeeplyCopyMap(newtRef * dst, size_t * pos, newtRefArg src);
 static newtRef		NewtDeeplyCloneMap(newtRefArg map, size_t len);
 static void			NewtObjRemoveFrameSlot(newtObjRef obj, newtRefArg slot);
-static bool			NewtStrNBeginsWith(char * str, size_t len, char * sub, size_t sublen);
-static bool			NewtStrIsSubclass(char * sub, size_t sublen, char * supr, size_t suprlen);
-static bool			NewtStrHasSubclass(char * sub, size_t sublen, char * supr, size_t suprlen);
+static bool			NewtStrNBeginsWith(const char * str, size_t len, const char * sub, size_t sublen);
+static bool			NewtStrIsSubclass(const char * sub, size_t sublen, const char * supr, size_t suprlen);
+static bool			NewtStrHasSubclass(const char * sub, size_t sublen, const char * supr, size_t suprlen);
 
 
 #if 0
@@ -4116,7 +4116,7 @@ void * NewtRefToNativeFn(newtRefArg r)
  * @return				関数オブジェクト
  */
 
-newtRef NewtMakeNativeFn0(void * funcPtr, size_t numArgs, bool indefinite, char * doc)
+newtRef NewtMakeNativeFn0(void * funcPtr, size_t numArgs, bool indefinite, const char * doc)
 {
     newtRefVar	fnv[] = {
                             NS_CLASS,			NSSYM0(_function.native0),
@@ -4152,7 +4152,7 @@ newtRef NewtMakeNativeFn0(void * funcPtr, size_t numArgs, bool indefinite, char 
  * @return				関数オブジェクト
  */
 
-newtRef NewtDefGlobalFn0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, char * doc)
+newtRef NewtDefGlobalFn0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, const char * doc)
 {
     newtRefVar	fn;
 
@@ -4172,7 +4172,7 @@ newtRef NewtDefGlobalFn0(newtRefArg sym, void * funcPtr, size_t numArgs, bool in
  * @return				関数オブジェクト
  */
 
-newtRef NewtMakeNativeFunc0(void * funcPtr, size_t numArgs, bool indefinite, char * doc)
+newtRef NewtMakeNativeFunc0(void * funcPtr, size_t numArgs, bool indefinite, const char * doc)
 {
     newtRefVar	fnv[] = {
                             NS_CLASS,			NSSYM0(_function.native),
@@ -4208,7 +4208,7 @@ newtRef NewtMakeNativeFunc0(void * funcPtr, size_t numArgs, bool indefinite, cha
  * @return				関数オブジェクト
  */
 
-newtRef NewtDefGlobalFunc0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, char * doc)
+newtRef NewtDefGlobalFunc0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, const char * doc)
 {
     newtRefVar	fn;
 
@@ -4232,7 +4232,7 @@ newtRef NewtDefGlobalFunc0(newtRefArg sym, void * funcPtr, size_t numArgs, bool 
  * @retval			false	前半部が部分文字列と一致しない
  */
 
-bool NewtStrNBeginsWith(char * str, size_t len, char * sub, size_t sublen)
+bool NewtStrNBeginsWith(const char * str, size_t len, const char * sub, size_t sublen)
 {
 	if (len < sublen)
 		return false;
@@ -4253,7 +4253,7 @@ bool NewtStrNBeginsWith(char * str, size_t len, char * sub, size_t sublen)
  * @retval			false	サブクラスでない
  */
 
-bool NewtStrIsSubclass(char * sub, size_t sublen, char * supr, size_t suprlen)
+bool NewtStrIsSubclass(const char * sub, size_t sublen, const char * supr, size_t suprlen)
 {
     if (sublen == suprlen)
         return (strncasecmp(sub, supr, suprlen) == 0);
@@ -4280,10 +4280,10 @@ bool NewtStrIsSubclass(char * sub, size_t sublen, char * supr, size_t suprlen)
  * @retval			false	サブクラスを含まない
  */
 
-bool NewtStrHasSubclass(char * sub, size_t sublen, char * supr, size_t suprlen)
+bool NewtStrHasSubclass(const char * sub, size_t sublen, const char * supr, size_t suprlen)
 {
-    char *	last;
-    char *	w;
+    const char *	last;
+    const char *	w;
 
     last = sub + sublen;
 
@@ -4384,7 +4384,7 @@ bool NewtIsInstance(newtRefArg obj, newtRefArg r)
  * @return			文字列オブジェクト
  */
 
-newtRef NewtStrCat(newtRefArg r, char * s)
+newtRef NewtStrCat(newtRefArg r, const char * s)
 {
     if (NewtRefIsPointer(r))
 		return NewtStrCat2(r, s, strlen(s));
@@ -4403,7 +4403,7 @@ newtRef NewtStrCat(newtRefArg r, char * s)
  * @return			文字列オブジェクト
  */
 
-newtRef NewtStrCat2(newtRefArg r, char * s, size_t slen)
+newtRef NewtStrCat2(newtRefArg r, const char * s, size_t slen)
 {
     newtObjRef	obj;
 

--- a/src/newt_core/incs/NewtNSOF.h
+++ b/src/newt_core/incs/NewtNSOF.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 
-newtRef		NewtReadNSOF(uint8_t * data, size_t size);
+newtRef		NewtReadNSOF(const uint8_t * data, size_t size);
 
 newtRef		NsMakeNSOF(newtRefArg rcvr, newtRefArg r, newtRefArg ver);
 newtRef		NsReadNSOF(newtRefArg rcvr, newtRefArg r);

--- a/src/newt_core/incs/NewtObj.h
+++ b/src/newt_core/incs/NewtObj.h
@@ -179,7 +179,7 @@ int			NewtRefFunctionType(newtRefArg r);
 bool		NewtRefIsRegex(newtRefArg r);
 void *		NewtRefToAddress(newtRefArg r);
 
-newtRef		NewtMakeBinary(newtRefArg klass, uint8_t * data, size_t size, bool literal);
+newtRef		NewtMakeBinary(newtRefArg klass, const uint8_t * data, size_t size, bool literal);
 newtRef		NewtMakeBinaryFromHex(newtRefArg klass, const char *hex, bool literal);
 newtRef		NewtMakeSymbol(const char *s);
 newtRef		NewtMakeString(const char *s, bool literal);

--- a/src/newt_core/incs/NewtObj.h
+++ b/src/newt_core/incs/NewtObj.h
@@ -265,18 +265,18 @@ bool		NewtHasVariable(newtRefArg r, newtRefArg name);
 
 void *		NewtRefToNativeFn(newtRefArg r);
 // old style
-newtRef		NewtMakeNativeFn0(void * funcPtr, size_t numArgs, bool indefinite, char * doc);
-newtRef		NewtDefGlobalFn0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, char * doc);
+newtRef		NewtMakeNativeFn0(void * funcPtr, size_t numArgs, bool indefinite, const char * doc);
+newtRef		NewtDefGlobalFn0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, const char * doc);
 // new style
-newtRef		NewtMakeNativeFunc0(void * funcPtr, size_t numArgs, bool indefinite, char * doc);
-newtRef		NewtDefGlobalFunc0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, char * doc);
+newtRef		NewtMakeNativeFunc0(void * funcPtr, size_t numArgs, bool indefinite, const char * doc);
+newtRef		NewtDefGlobalFunc0(newtRefArg sym, void * funcPtr, size_t numArgs, bool indefinite, const char * doc);
 
 bool		NewtHasSubclass(newtRefArg sub, newtRefArg supr);
 bool		NewtIsSubclass(newtRefArg sub, newtRefArg supr);
 bool		NewtIsInstance(newtRefArg obj, newtRefArg r);
 
-newtRef		NewtStrCat(newtRefArg r, char * s);
-newtRef		NewtStrCat2(newtRefArg r, char * s, size_t slen);
+newtRef		NewtStrCat(newtRefArg r, const char * s);
+newtRef		NewtStrCat2(newtRefArg r, const char * s, size_t slen);
 
 newtRef		NewtGetEnv(const char * s);
 


### PR DESCRIPTION
We don't modify these strings/buffers.
This will avoid any warning related to constant literal strings in C++11